### PR TITLE
Fixes for Elasticsearch script

### DIFF
--- a/elasticsearch/count.sh
+++ b/elasticsearch/count.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 
 # Check if the required arguments are provided
 if [[ $# -lt 1 ]]; then

--- a/elasticsearch/create_and_load.sh
+++ b/elasticsearch/create_and_load.sh
@@ -25,9 +25,8 @@ ERROR_LOG="$6"
 [[ ! -d "$DATA_DIRECTORY" ]] && { echo "Error: Data directory '$DATA_DIRECTORY' does not exist."; exit 1; }
 [[ ! "$NUM_FILES" =~ ^[0-9]+$ ]] && { echo "Error: NUM_FILES must be a positive integer."; exit 1; }
 
-# Check ilm policy is installed, install if not
+echo "Checking if ILM policy is installed, install if not"
 # If curl return 404, means ILM policy is not installed
-
 http_code=$(curl -s -o /dev/null -k -w "%{http_code}" -X GET "https://localhost:9200/_ilm/policy/filebeat" -u "elastic:${ELASTIC_PASSWORD}" -H 'Content-Type: application/json')
 if [[ "$http_code" -eq 404 ]] ; then
     echo "Installing ILM policy"
@@ -35,18 +34,16 @@ if [[ "$http_code" -eq 404 ]] ; then
     curl -s -k -X PUT "https://localhost:9200/_ilm/policy/filebeat" -u "elastic:${ELASTIC_PASSWORD}" -H 'Content-Type: application/json' -d "$ILM_POLICY"
 fi
 
-# Install index template
-# Read index template file json from config/$INDEX_TEMPLATE_FILE 
+echo "Installing index template"
+# Read index template file json from config/$INDEX_TEMPLATE_FILE
 INDEX_TEMPLATE=$(cat "$INDEX_TEMPLATE_FILE")
 JSON_DATA=$(cat $INDEX_TEMPLATE_FILE | sed "s/\${INDEX_NAME}/$INDEX_NAME/g")
 echo "Install index template"
 curl -s -o /dev/null -k -X PUT "https://localhost:9200/_index_template/${INDEX_NAME}" -u "elastic:${ELASTIC_PASSWORD}" -H 'Content-Type: application/json' -d "$JSON_DATA"
 
-# Create the data stream
+echo "Creating the data stream"
 echo "Create the data stream"
 curl -s -o /dev/null -k -X PUT "https://localhost:9200/_data_stream/${INDEX_NAME}" -u "elastic:${ELASTIC_PASSWORD}" -H 'Content-Type: application/json'
 
-# Load data
+echo "Loading data"
 ./load_data.sh "$DATA_DIRECTORY" "$INDEX_NAME" "$NUM_FILES" "$SUCCESS_LOG" "$ERROR_LOG"
-
-echo "Script completed successfully."

--- a/elasticsearch/drop_tables.sh
+++ b/elasticsearch/drop_tables.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+echo "Stopping ElasticSearch"
+sudo systemctl stop elasticsearch.service
+
+# My amateurish attempt to delete data from Elasticsearch led me to
+# - https://stackoverflow.com/questions/22924300/removing-data-from-elasticsearch
+# - https://stackoverflow.com/questions/23917327/delete-all-documents-from-index-without-deleting-index
+# but none of that worked for me so I gave up after debugging this mess for 90 minutes.
+
+# Let's try it the old-fashioned way.
+
+# echo "Nuking ElasticSearch directories"
+# sudo rm -rf /var/lib/elasticsearch/*
+# sudo rm -rf /var/log/elasticsearch/*
+
+# ^^ Haha. Fails silently, please `sudo su` and run above `rm` statements by hand. But don't delete the elasticsearch/ folders themselves,
+# otherwise elasticsearch will refuse to start and you will need to re-install it via apt. What a shameful disaster. If someone knows how to
+# perform the extremely simple task of deleting data from Elasticsearch, please send a pull request.

--- a/elasticsearch/install.sh
+++ b/elasticsearch/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 
 # Install elasticsearch
 wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo gpg --dearmor -o /usr/share/keyrings/elasticsearch-keyring.gpg
@@ -6,39 +6,10 @@ sudo apt-get install apt-transport-https
 echo "deb [signed-by=/usr/share/keyrings/elasticsearch-keyring.gpg] https://artifacts.elastic.co/packages/8.x/apt stable main" | sudo tee /etc/apt/sources.list.d/elastic-8.x.list
 sudo apt-get update && sudo apt-get install elasticsearch
 
-# # Install filebeat
+# Install filebeat
 curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-8.17.0-amd64.deb
 sudo dpkg -i filebeat-8.17.0-amd64.deb
 
-# # Overwrite configuration files
+# Overwrite configuration files
 sudo cp config/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml
 sudo cp config/jvm.options /etc/elasticsearch/jvm.options
-
-# # Start elasticsearch
-sudo systemctl start elasticsearch.service
-
-# Reset and export elastic password
-export ELASTIC_PASSWORD=$(sudo /usr/share/elasticsearch/bin/elasticsearch-reset-password -s -a -b -u elastic)
-
-# Save elastic password in local file
-echo "ELASTIC_PASSWORD=$ELASTIC_PASSWORD" > .elastic_password
-
-# Generate api key for filebeat
-curl -s -k -X POST "https://localhost:9200/_security/api_key" -u "elastic:${ELASTIC_PASSWORD}" -H 'Content-Type: application/json' -d '
-{
-  "name": "filebeat",
-  "role_descriptors": {
-    "filebeat_writer": { 
-      "cluster": ["monitor", "read_ilm", "read_pipeline"],
-      "index": [
-        {
-          "names": ["bluesky-*"],
-          "privileges": ["view_index_metadata", "create_doc", "auto_configure"]
-        }
-      ]
-    }
-  }
-}' | jq -r '"\(.id):\(.api_key)"' > .filebeat_api_key
-
-
-

--- a/elasticsearch/main.sh
+++ b/elasticsearch/main.sh
@@ -30,6 +30,7 @@ read -p "Enter the number corresponding to your choice: " choice
 ./install.sh
 
 benchmark() {
+    ./start.sh
     local size=$1
     local template=$2
     # Check DATA_DIRECTORY contains the required number of files to run the benchmark
@@ -43,6 +44,7 @@ benchmark() {
     ./count.sh "bluesky-${template}-${size}m" | tee "${OUTPUT_PREFIX}_bluesky-${template}-${size}m.count"
     #./query_results.sh "bluesky-${template}-${size}m" | tee "${OUTPUT_PREFIX}_bluesky-${template}-${size}m.query_results"
     ./benchmark.sh "bluesky-${template}-${size}m" "${OUTPUT_PREFIX}_bluesky-${template}-${size}m.results_runtime"
+    ./drop_tables.sh
 }
 
 case $choice in

--- a/elasticsearch/start.sh
+++ b/elasticsearch/start.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+echo "Starting ElasticSearch"
+sudo systemctl start elasticsearch.service
+
+echo "Resetting and export ElasticSearch password"
+export ELASTIC_PASSWORD=$(sudo /usr/share/elasticsearch/bin/elasticsearch-reset-password -s -a -b -u elastic)
+
+echo "Saving ElasticSearch password in local file"
+echo "ELASTIC_PASSWORD=$ELASTIC_PASSWORD" > .elastic_password
+
+echo "Generating API key for filebeat"
+curl -s -k -X POST "https://localhost:9200/_security/api_key" -u "elastic:${ELASTIC_PASSWORD}" -H 'Content-Type: application/json' -d '
+{
+  "name": "filebeat",
+  "role_descriptors": {
+    "filebeat_writer": {
+      "cluster": ["monitor", "read_ilm", "read_pipeline"],
+      "index": [
+        {
+          "names": ["bluesky-*"],
+          "privileges": ["view_index_metadata", "create_doc", "auto_configure"]
+        }
+      ]
+    }
+  }
+}' | jq -r '"\(.id):\(.api_key)"' > .filebeat_api_key

--- a/victorialogs/main.sh
+++ b/victorialogs/main.sh
@@ -44,7 +44,7 @@ benchmark() {
     ./data_size.sh | tee "${OUTPUT_PREFIX}_bluesky_${size}m.data_size"
     ./index_size.sh | tee "${OUTPUT_PREFIX}_bluesky_${size}m.index_size"
     ./count.sh | tee "${OUTPUT_PREFIX}_bluesky_${size}m.count"
-    # #./query_results.sh | tee "${OUTPUT_PREFIX}_bluesky_${size}m.query_results"
+    #./query_results.sh | tee "${OUTPUT_PREFIX}_bluesky_${size}m.query_results"
     ./run_queries.sh | tee "${OUTPUT_PREFIX}_bluesky_${size}m.results_runtime"
     ./drop_tables.sh # also stops VictoriaLogs
 }

--- a/victorialogs/main.sh
+++ b/victorialogs/main.sh
@@ -31,21 +31,21 @@ read -p "Enter the number corresponding to your choice: " choice
 
 benchmark() {
     local size=$1
-
+    # Check DATA_DIRECTORY contains the required number of files to run the benchmark
+    file_count=$(find "$DATA_DIRECTORY" -type f | wc -l)
+    if (( file_count < size )); then
+        echo "Error: Not enough files in '$DATA_DIRECTORY'. Required: $size, Found: $file_count."
+        exit 1
+    fi
     ./start.sh
-
     ./load_data.sh "$DATA_DIRECTORY" "$size" "$SUCCESS_LOG" "$ERROR_LOG"
-
-    # sleep for a while for settling down the data
-    sleep 1
-
+    sleep 1 # sleep for a while for settling down the data
     ./total_size.sh | tee "${OUTPUT_PREFIX}_bluesky_${size}m.total_size"
     ./data_size.sh | tee "${OUTPUT_PREFIX}_bluesky_${size}m.data_size"
     ./index_size.sh | tee "${OUTPUT_PREFIX}_bluesky_${size}m.index_size"
     ./count.sh | tee "${OUTPUT_PREFIX}_bluesky_${size}m.count"
-    #./query_results.sh | tee "${OUTPUT_PREFIX}_bluesky_${size}m.query_results"
+    # #./query_results.sh | tee "${OUTPUT_PREFIX}_bluesky_${size}m.query_results"
     ./run_queries.sh | tee "${OUTPUT_PREFIX}_bluesky_${size}m.results_runtime"
-
     ./drop_tables.sh # also stops VictoriaLogs
 }
 

--- a/victorialogs/run_queries.sh
+++ b/victorialogs/run_queries.sh
@@ -16,14 +16,14 @@ cat queries.logsql | while read -r query; do
     # Execute the query multiple times
     echo -n "["
     for i in $(seq 1 $TRIES); do
-	t1=$(date +%s%3N)
-	curl -s --fail http://localhost:9428/select/logsql/query --data-urlencode "query=$query" > /dev/null
-	exit_code=$?
-	t2=$(date +%s%3N)
-	duration=$((t2-t1))
-	RES=$(awk "BEGIN {print $duration / 1000}" | tr ',' '.')
-        [[ "$exit_code" == "0" ]] && echo -n "${RES}" || echo -n "null"
-        [[ "$i" != $TRIES ]] && echo -n ", "
+        t_start=$(date +%s%3N)
+        curl -s --fail http://localhost:9428/select/logsql/query --data-urlencode "query=$query" > /dev/null
+        exit_code=$?
+        t_end=$(date +%s%3N)
+        duration=$((t_end-t_start))
+        RES=$(awk "BEGIN {print $duration / 1000}" | tr ',' '.')
+            [[ "$exit_code" == "0" ]] && echo -n "${RES}" || echo -n "null"
+            [[ "$i" != $TRIES ]] && echo -n ", "
     done
     echo "]"
 


### PR DESCRIPTION
Added a routine (at least tried to) which drops the inserted data at the end of the benchmark. Without such a routine, repeated benchmark runs would accumulate data in existing Elasticsearch indexes.