### PR TITLE
Elasticsearch: Fix attribute in result json

### DIFF
--- a/elasticsearch/results/m6i.8xlarge_bluesky_no_source_100m_best_compression.json
+++ b/elasticsearch/results/m6i.8xlarge_bluesky_no_source_100m_best_compression.json
@@ -13,8 +13,8 @@
   "dataset_size_readable": "100m",
   "num_loaded_documents": 99999947,
   "data_compression": "zstd",
-  "data_size": 21268479403,
-  "data_size_readable": "19.8 GB",
+  "total_size": 21268479403,
+  "total_size_readable": "21.2 GB",
   "result": [
     [2.532,2.536,2.486],
     [23.194,22.932,23.188],


### PR DESCRIPTION
One of the Elasticsearch result JSONs documents accidentally used a wrong attribute `data_size[_readable]` instead of `total_size[_readable]`. This led to the document described in https://github.com/ClickHouse/JSONBench/pull/27. 