### PR TITLE
Fix sed aliasing in generate-results.sh for macOS

### DIFF
--- a/generate-results.sh
+++ b/generate-results.sh
@@ -7,6 +7,7 @@
 [ -n "$HOMEBREW_PREFIX" ] && PATH="${HOMEBREW_PREFIX}/opt/coreutils/libexec/gnubin:${PATH}"
 if command -v gsed >/dev/null 2>&1
 then
+    shopt -s expand_aliases
     alias sed='gsed'
 fi
 


### PR DESCRIPTION
Applies https://github.com/ClickHouse/ClickBench/pull/352 in JSONBench