### PR TITLE
[BugFix] fix the time measurement of run_queries.sh

### DIFF
--- a/starrocks/run_queries.sh
+++ b/starrocks/run_queries.sh
@@ -26,7 +26,7 @@ cat queries.sql | while read -r query; do
 
     # Execute the query multiple times
     for i in $(seq 1 $TRIES); do
-        RESP=$({ /usr/bin/time -f '%e' \
+        RESP=$({ time -f '%e' \
                     mysql -N -s -h "$DB_HOST" -P "$DB_MYSQL_PORT" -u"$DB_USER" "$DB_NAME" \
                     -e "$query" >/dev/null; } 2>&1)
         echo "Response time: ${RESP} s"


### PR DESCRIPTION
Using `mysql -vvv` may produce output that isn't recognized by the regex, leading to an empty `Response time`. To address this, switch to `/usr/bin/time` for measuring execution time.

```
--------------
SELECT sleep(60)
--------------

+-----------+
| sleep(60) |
+-----------+
|         1 |
+-----------+
1 row in set (1 min 0.01 sec)

Bye
```
